### PR TITLE
Benchmarking some alternatives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "@types/seedrandom": "^3.0.1",
         "0x": "^4.10.2",
         "benchmark": "^2.1.4",
+        "elasticlunr": "^0.9.5",
         "husky": "^7.0.1",
         "lodash": "^4.17.21",
+        "lunr": "^2.3.9",
         "np": "^7.5.0",
         "seedrandom": "^3.0.5",
         "size-limit": "^5.0.3",
@@ -6327,6 +6329,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/elasticlunr": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/elasticlunr/-/elasticlunr-0.9.5.tgz",
+      "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU=",
+      "dev": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.3.811",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.811.tgz",
@@ -11771,6 +11779,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
     },
     "node_modules/magic-string": {
       "version": "0.25.7",
@@ -24948,6 +24962,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "elasticlunr": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/elasticlunr/-/elasticlunr-0.9.5.tgz",
+      "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU=",
+      "dev": true
+    },
     "electron-to-chromium": {
       "version": "1.3.811",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.811.tgz",
@@ -29197,6 +29217,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.7",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "analyze": "size-limit --why",
     "benchmark": "npm run build && NODE_ENV=production 0x -o ./test/benchmark",
     "benchmark-flatList": "npm run build && NODE_ENV=production 0x -o ./test/flatListBenchmark",
+    "benchmark-suffixTree": "npm run build && NODE_ENV=production 0x -o ./test/suffixTreeBenchmark",
     "build": "tsdx build",
     "lint": "tsdx lint",
     "prepack": "tsdx build",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "benchmark": "npm run build && NODE_ENV=production 0x -o ./test/benchmark",
     "benchmark-flatList": "npm run build && NODE_ENV=production 0x -o ./test/flatListBenchmark",
     "benchmark-suffixTree": "npm run build && NODE_ENV=production 0x -o ./test/suffixTreeBenchmark",
+    "benchmark-lunr": "npm run build && NODE_ENV=production 0x -o ./test/lunrBenchmark",
+    "benchmark-elasticlunr": "npm run build && NODE_ENV=production 0x -o ./test/elasticlunrBenchmark",
     "build": "tsdx build",
     "lint": "tsdx lint",
     "prepack": "tsdx build",
@@ -63,7 +65,9 @@
     "size-limit": "^5.0.3",
     "tsdx": "^0.14.1",
     "tslib": "^2.3.1",
-    "typescript": "^3.9.10"
+    "typescript": "^3.9.10",
+    "lunr": "^2.3.9",
+    "elasticlunr": "^0.9.5"
   },
   "repository": "github:shortwave/trie"
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "benchmark": "npm run build && NODE_ENV=production 0x -o ./test/benchmark",
+    "benchmark-flatList": "npm run build && NODE_ENV=production 0x -o ./test/flatListBenchmark",
     "build": "tsdx build",
     "lint": "tsdx lint",
     "prepack": "tsdx build",

--- a/src/flatList.ts
+++ b/src/flatList.ts
@@ -1,0 +1,97 @@
+import { sortBy } from 'lodash';
+import { Item, SearchOptions } from './common';
+
+class FlatList<T> {
+  public list: Item<T>[] = [];
+  public sorted: boolean = false;
+
+  constructor() {}
+
+  validateInvariants(): void {
+    if (process.env.NODE_ENV === 'production') return;
+    return;
+  }
+
+  add(item: Item<T>) {
+    this.list.push(item);
+    this.sorted = false;
+  }
+
+  remove(target: Pick<Item<never>, 'key' | 'distinct'>) {
+    this.list = this.list.filter(
+      item => item.key !== target.key || item.distinct !== target.distinct
+    );
+  }
+
+  unsortedPrefixSearch(prefix: string, opts?: Partial<SearchOptions>): T[] {
+    const options: SearchOptions = {
+      unique: opts?.unique ?? false,
+      limit: opts?.limit ?? Number.POSITIVE_INFINITY,
+    };
+
+    const results = sortBy(
+      this.list.filter(item => item.key.startsWith(prefix)),
+      item => item.score
+    );
+    const seenKeys = new Set<string>();
+    const out: T[] = [];
+    for (const item of results) {
+      if (options.unique && seenKeys.has(item.key)) continue;
+      seenKeys.add(item.key);
+      out.push(item.value);
+      if (out.length >= options.limit) break;
+    }
+
+    return out;
+  }
+
+  sort(): void {
+    if (this.sorted) return;
+    this.list = sortBy(this.list, item => item.score);
+    this.sorted = true;
+  }
+
+  sortedPrefixSearch(prefix: string, opts?: Partial<SearchOptions>): T[] {
+    if (!this.sorted)
+      throw new Error('The list must be sorted in order to use this');
+    const options: SearchOptions = {
+      unique: opts?.unique ?? false,
+      limit: opts?.limit ?? Number.POSITIVE_INFINITY,
+    };
+
+    const seenKeys = new Set<string>();
+    const out: T[] = [];
+    for (const item of this.list) {
+      if (options.unique && seenKeys.has(item.key)) continue;
+      if (!item.key.startsWith(prefix)) continue;
+      seenKeys.add(item.key);
+      out.push(item.value);
+      if (out.length >= options.limit) break;
+    }
+
+    return out;
+  }
+
+  sortedSubstringSearch(str: string, opts?: Partial<SearchOptions>): T[] {
+    if (!this.sorted)
+      throw new Error('The list must be sorted in order to use this');
+    const options: SearchOptions = {
+      unique: opts?.unique ?? false,
+      limit: opts?.limit ?? Number.POSITIVE_INFINITY,
+    };
+
+    const seenKeys = new Set<string>();
+    const out: T[] = [];
+    for (const item of this.list) {
+      if (options.unique && seenKeys.has(item.key)) continue;
+      if (!item.key.includes(str)) continue;
+      seenKeys.add(item.key);
+      out.push(item.value);
+      if (out.length >= options.limit) break;
+    }
+
+    return out;
+  }
+}
+
+export { FlatList as default, Item };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import Node from './node';
 import { Item, SearchOptions } from './common';
+import { roughSizeOfObject } from './utils';
 
 interface TrieOptions {
   readonly maxWidth: number;
@@ -85,4 +86,4 @@ class Trie<T> {
   }
 }
 
-export { Trie as default, Item, TrieOptions, SearchOptions };
+export { Trie as default, Item, TrieOptions, SearchOptions, roughSizeOfObject };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import Node from './node';
 import { Item, SearchOptions } from './common';
+import FlatList from './flatList';
 import { roughSizeOfObject } from './utils';
 
 interface TrieOptions {
@@ -86,4 +87,11 @@ class Trie<T> {
   }
 }
 
-export { Trie as default, Item, TrieOptions, SearchOptions, roughSizeOfObject };
+export {
+  Trie as default,
+  Item,
+  TrieOptions,
+  SearchOptions,
+  FlatList,
+  roughSizeOfObject,
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,3 +15,55 @@ export function filterInPlace<T>(
   }
   arr.splice(j, arr.length - j);
 }
+
+function assertNever(x: never): never {
+  throw new Error(`Unknown type for object: ${x}`);
+}
+
+export function roughSizeOfObject(obj: any) {
+  const seenObjects = new Set<any>();
+  const stack = [obj];
+  let bytes = 0;
+
+  while (stack.length > 0) {
+    const value = stack.pop();
+
+    const valueType = typeof value;
+    switch (valueType) {
+      case 'undefined':
+        break;
+      case 'function':
+        // Not sure, zero I guess?
+        break;
+      case 'boolean':
+        bytes += 4;
+        break;
+      case 'number':
+        bytes += 8;
+        break;
+      case 'string':
+        bytes += value.length * 2;
+        break;
+      case 'bigint':
+        bytes += value.toString().length * 2;
+        break;
+      case 'symbol':
+        bytes += 1; // Just for the reference?
+        if (seenObjects.has(value)) break;
+        seenObjects.add(value);
+        bytes += (value.description?.length ?? 1) * 2;
+        break;
+      case 'object':
+        bytes += 1; // Just for the reference?
+        if (seenObjects.has(value)) break;
+        seenObjects.add(value);
+        for (const i in value) {
+          stack.push(value[i]);
+        }
+        break;
+      default:
+        assertNever(valueType);
+    }
+  }
+  return bytes;
+}

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,5 +1,5 @@
 const contacts = require('./contacts.json');
-const { default: Trie } = require('../dist');
+const { default: Trie, roughSizeOfObject } = require('../dist');
 
 const Benchmark = require('benchmark');
 
@@ -32,16 +32,15 @@ suite.add('Trie#populate', () => setup(new Trie()));
 
 function addBenchmarkTest(prefix, limit) {
   const t = new Trie();
-  suite.add(
-    `Trie#lookupPrefix(${prefix}, ${limit})`,
-    function() {
-      t.prefixSearch(prefix, { limit, unique: true });
-    },
-    { setup: () => setup(t) }
-  );
+  setup(t);
+  suite.add(`Trie#lookupPrefix(${prefix}, ${limit})`, function() {
+    t.prefixSearch(prefix, { limit, unique: true });
+  });
 }
 
+addBenchmarkTest('', 5);
 addBenchmarkTest('t', 5);
+addBenchmarkTest('somethingthatwontevermatchanythingatall', 5);
 addBenchmarkTest('tee', 3);
 addBenchmarkTest('tee', 6);
 
@@ -54,5 +53,19 @@ suite.on('cycle', event => console.log(String(event.target)));
  0.064667
  LookupPrefix:
  LookupPrefix x 2,206,769 ops/sec ±0.85% (95 runs sampled)
+
+
+Trie#populate x 7.50 ops/sec ±2.48% (19 runs sampled)
+Trie#lookupPrefix(, 5) x 2,144 ops/sec ±1.63% (85 runs sampled)
+Trie#lookupPrefix(t, 5) x 23,947 ops/sec ±0.23% (89 runs sampled)
+Trie#lookupPrefix(somethingthatwontevermatchanythingatall, 5) x 12,691,661 ops/sec ±0.63% (87 runs sampled)
+Trie#lookupPrefix(tee, 3) x 3,540,266 ops/sec ±0.18% (88 runs sampled)
+Trie#lookupPrefix(tee, 6) x 1,663,454 ops/sec ±0.79% (87 runs sampled)
+Rough size of Trie 34.9750337600708 MB
  */
 suite.run();
+
+const t = new Trie();
+setup(t);
+const BYTES_IN_MB = 1024 * 1024;
+console.log('Rough size of Trie', roughSizeOfObject(t) / BYTES_IN_MB, 'MB');

--- a/test/elasticlunrBenchmark.js
+++ b/test/elasticlunrBenchmark.js
@@ -1,0 +1,57 @@
+const contacts = require('./contacts.json');
+const { roughSizeOfObject } = require('../dist');
+
+const Benchmark = require('benchmark');
+const lunr = require('elasticlunr');
+
+const suite = new Benchmark.Suite();
+
+function setup() {
+  return lunr(function() {
+    this.addField('name');
+    this.addField('email');
+    this.setRef('distinct');
+
+    contacts.forEach(data => {
+      const score = data.score;
+      const email = (data.email || '-').toLowerCase();
+      const name = data.name.toLowerCase();
+      const distinct = email + name;
+      this.addDoc({ score, email, name, distinct });
+    });
+  });
+}
+
+suite.add('elasticlunr#populate', () => setup());
+
+function addBenchmarkTest(prefix) {
+  const t = setup();
+  suite.add(`elasticlunr#search(${prefix})`, function() {
+    t.search(prefix, {});
+  });
+}
+
+addBenchmarkTest('');
+addBenchmarkTest('t');
+addBenchmarkTest('somethingthatwontevermatchanythingatall');
+addBenchmarkTest('tee');
+
+suite.on('cycle', event => console.log(String(event.target)));
+
+/*
+elasticlunr#populate x 0.34 ops/sec ±37.07% (5 runs sampled)
+elasticlunr#search() x 852,101,814 ops/sec ±0.70% (86 runs sampled)
+elasticlunr#search(t) x 356 ops/sec ±1.08% (81 runs sampled)
+elasticlunr#search(somethingthatwontevermatchanythingatall) x 265,674 ops/sec ±1.22% (83 runs sampled)
+elasticlunr#search(tee) x 373,034 ops/sec ±0.58% (84 runs sampled)
+Rough size of elasticlunr 34.31093978881836 MB
+ */
+suite.run();
+
+const t = setup();
+const BYTES_IN_MB = 1024 * 1024;
+console.log(
+  'Rough size of elasticlunr',
+  roughSizeOfObject(t) / BYTES_IN_MB,
+  'MB'
+);

--- a/test/flatListBenchmark.js
+++ b/test/flatListBenchmark.js
@@ -1,0 +1,125 @@
+// import contacts from './contacts.json';
+// import { FlatList } from '../dist';
+// import { once } from 'lodash';
+
+// import Benchmark from 'benchmark';
+const contacts = require('./contacts.json');
+const { FlatList, roughSizeOfObject } = require('../dist');
+
+const Benchmark = require('benchmark');
+
+// interface Contact {
+//   readonly name: string;
+//   readonly email: string;
+//   readonly score: number;
+// }
+// const typedContacts = contacts as readonly Contact[];
+
+const suite = new Benchmark.Suite();
+
+function setup(t) {
+  contacts.forEach(function(data) {
+    const email = (data.email || '-').toLowerCase();
+    const name = data.name.toLowerCase();
+
+    const score = data.score;
+
+    t.add({
+      key: email,
+      score: score,
+      value: data,
+      distinct: email + name,
+    });
+
+    t.add({
+      key: name,
+      score: score,
+      value: data,
+      distinct: email + name,
+    });
+  });
+}
+
+suite.add('FlatList#populate', () => setup(new FlatList()));
+
+function addBenchmarkTest(prefix, limit) {
+  const t = new FlatList();
+  setup(t);
+  suite.add(
+    `FlatList#lookupPrefix(${prefix}, ${limit})`,
+    function() {
+      t.unsortedPrefixSearch(prefix, { limit, unique: true });
+    },
+    { setup: () => setup(t) }
+  );
+}
+
+addBenchmarkTest('', 5);
+addBenchmarkTest('t', 5);
+addBenchmarkTest('somethingthatwontevermatchanythingatall', 5);
+addBenchmarkTest('tee', 3);
+addBenchmarkTest('tee', 6);
+
+function sortedSetup(t) {
+  setup(t);
+  t.sort();
+}
+
+suite.add('FlatList#populateSort', () => sortedSetup(new FlatList()));
+
+function addSortedBenchmarkTest(prefix, limit) {
+  const t = new FlatList();
+  sortedSetup(t);
+  suite.add(`FlatList#lookupPrefixSorted(${prefix}, ${limit})`, function() {
+    t.sortedPrefixSearch(prefix, { limit, unique: true });
+  });
+}
+
+addSortedBenchmarkTest('', 5);
+addSortedBenchmarkTest('t', 5);
+addSortedBenchmarkTest('somethingthatwontevermatchanythingatall', 5);
+addSortedBenchmarkTest('tee', 3);
+addSortedBenchmarkTest('tee', 6);
+
+function addSortedSubstringBenchmarkTest(prefix, limit) {
+  const t = new FlatList();
+  sortedSetup(t);
+  suite.add(`FlatList#lookupSubstringSorted(${prefix}, ${limit})`, function() {
+    t.sortedSubstringSearch(prefix, { limit, unique: true });
+  });
+}
+
+addSortedSubstringBenchmarkTest('', 5);
+addSortedSubstringBenchmarkTest('t', 5);
+addSortedSubstringBenchmarkTest('somethingthatwontevermatchanythingatall', 5);
+addSortedSubstringBenchmarkTest('tee', 3);
+addSortedSubstringBenchmarkTest('tee', 6);
+
+suite.on('cycle', event => console.log(String(event.target)));
+
+/*
+FlatList#populate x 14.75 ops/sec ±38.84% (31 runs sampled)
+FlatList#lookupPrefix(, 5) x 3.25 ops/sec ±3.37% (13 runs sampled)
+FlatList#lookupPrefix(t, 5) x 64.29 ops/sec ±8.76% (54 runs sampled)
+FlatList#lookupPrefix(somethingthatwontevermatchanythingatall, 5) x 169 ops/sec ±0.61% (73 runs sampled)
+FlatList#lookupPrefix(tee, 3) x 166 ops/sec ±2.96% (76 runs sampled)
+FlatList#lookupPrefix(tee, 6) x 190 ops/sec ±0.56% (75 runs sampled)
+FlatList#populateSort x 2.24 ops/sec ±32.55% (11 runs sampled)
+FlatList#lookupPrefixSorted(, 5) x 1,906,935 ops/sec ±0.98% (87 runs sampled)
+FlatList#lookupPrefixSorted(t, 5) x 171,410 ops/sec ±2.02% (88 runs sampled)
+FlatList#lookupPrefixSorted(somethingthatwontevermatchanythingatall, 5) x 32.11 ops/sec ±1.00% (53 runs sampled)
+FlatList#lookupPrefixSorted(tee, 3) x 944 ops/sec ±1.26% (77 runs sampled)
+FlatList#lookupPrefixSorted(tee, 6) x 484 ops/sec ±2.60% (63 runs sampled)
+FlatList#lookupSubstringSorted(, 5) x 2,150,871 ops/sec ±1.29% (87 runs sampled)
+FlatList#lookupSubstringSorted(t, 5) x 1,211,808 ops/sec ±0.84% (84 runs sampled)
+FlatList#lookupSubstringSorted(somethingthatwontevermatchanythingatall, 5) x 33.59 ops/sec ±0.28% (55 runs sampled)
+FlatList#lookupSubstringSorted(tee, 3) x 4,488 ops/sec ±1.18% (85 runs sampled)
+FlatList#lookupSubstringSorted(tee, 6) x 2,508 ops/sec ±0.94% (83 runs sampled)
+Rough size of FlatList 34.93774223327637 MB
+ */
+suite.run();
+
+const t = new FlatList();
+setup(t);
+const BYTES_IN_MB = 1024 * 1024;
+console.log('Rough size of FlatList', roughSizeOfObject(t) / BYTES_IN_MB, 'MB');

--- a/test/lunrBenchmark.js
+++ b/test/lunrBenchmark.js
@@ -1,0 +1,53 @@
+const contacts = require('./contacts.json');
+const { roughSizeOfObject } = require('../dist');
+
+const Benchmark = require('benchmark');
+const lunr = require('lunr');
+
+const suite = new Benchmark.Suite();
+
+function setup() {
+  return lunr(function() {
+    this.field('name');
+    this.field('email');
+    this.ref('distinct');
+
+    contacts.forEach(data => {
+      const score = data.score;
+      const email = (data.email || '-').toLowerCase();
+      const name = data.name.toLowerCase();
+      const distinct = email + name;
+      this.add({ score, email, name, distinct });
+    });
+  });
+}
+
+suite.add('lunr#populate', () => setup());
+
+function addBenchmarkTest(prefix) {
+  const t = setup();
+  suite.add(`lunr#search(${prefix})`, function() {
+    t.search(prefix);
+  });
+}
+
+addBenchmarkTest('');
+addBenchmarkTest('t');
+addBenchmarkTest('somethingthatwontevermatchanythingatall');
+addBenchmarkTest('tee');
+
+suite.on('cycle', event => console.log(String(event.target)));
+
+/*
+lunr#populate x 0.26 ops/sec ±3.60% (5 runs sampled)
+lunr#search() x 1.89 ops/sec ±49.26% (11 runs sampled)
+lunr#search(t) x 194 ops/sec ±1.99% (67 runs sampled)
+lunr#search(somethingthatwontevermatchanythingatall) x 130,564 ops/sec ±0.97% (86 runs sampled)
+lunr#search(tee) x 267,996 ops/sec ±1.18% (84 runs sampled)
+Rough size of lunr 16.319193840026855 MB
+ */
+suite.run();
+
+const t = setup();
+const BYTES_IN_MB = 1024 * 1024;
+console.log('Rough size of lunr', roughSizeOfObject(t) / BYTES_IN_MB, 'MB');

--- a/test/suffixTreeBenchmark.js
+++ b/test/suffixTreeBenchmark.js
@@ -1,0 +1,66 @@
+const contacts = require('./contacts.json');
+const { default: Trie, roughSizeOfObject } = require('../dist');
+
+const Benchmark = require('benchmark');
+
+const suite = new Benchmark.Suite();
+
+function suffixAdd(t, key, score, value, distinct) {
+  for (let q = 0; q < key.length; q++) {
+    t.add({
+      key: key.slice(q),
+      score,
+      value,
+      distinct,
+    });
+  }
+}
+
+function setup(t) {
+  contacts.forEach(function(data) {
+    const score = data.score;
+    const email = (data.email || '-').toLowerCase();
+    const name = data.name.toLowerCase();
+    const distinct = email + name;
+    suffixAdd(t, email, score, data, distinct);
+    suffixAdd(t, name, score, data, distinct);
+  });
+}
+
+suite.add('NaiveSuffixTrie#populate', () => setup(new Trie()));
+
+function addBenchmarkTest(prefix, limit) {
+  const t = new Trie();
+  setup(t);
+  suite.add(`NaiveSuffixTrie#lookupPrefix(${prefix}, ${limit})`, function() {
+    t.prefixSearch(prefix, { limit, unique: true });
+  });
+}
+
+addBenchmarkTest('', 5);
+addBenchmarkTest('t', 5);
+addBenchmarkTest('somethingthatwontevermatchanythingatall', 5);
+addBenchmarkTest('tee', 3);
+addBenchmarkTest('tee', 6);
+
+suite.on('cycle', event => console.log(String(event.target)));
+
+/*
+NaiveSuffixTrie#populate x 0.09 ops/sec ±69.35% (5 runs sampled)
+NaiveSuffixTrie#lookupPrefix(, 5) x 0.04 ops/sec ±97.39% (5 runs sampled)
+NaiveSuffixTrie#lookupPrefix(t, 5) x 44.25 ops/sec ±17.60% (58 runs sampled)
+NaiveSuffixTrie#lookupPrefix(somethingthatwontevermatchanythingatall, 5) x 928,325 ops/sec ±1.09% (86 runs sampled)
+NaiveSuffixTrie#lookupPrefix(tee, 3) x 2,414,849 ops/sec ±1.74% (76 runs sampled)
+NaiveSuffixTrie#lookupPrefix(tee, 6) x 1,524,420 ops/sec ±1.04% (78 runs sampled)
+Rough size of NaiceSuffixTrie 510.87034797668457 MB
+ */
+suite.run();
+
+const t = new Trie();
+setup(t);
+const BYTES_IN_MB = 1024 * 1024;
+console.log(
+  'Rough size of NaiceSuffixTrie',
+  roughSizeOfObject(t) / BYTES_IN_MB,
+  'MB'
+);


### PR DESCRIPTION
Using the same data and setup that this prefix trie uses I compared some other alternatives we were considering for contact suggestions.

* A plain list - faster than we were expecting, but right on the cusp of what we considered to be okay performance.
* Naive suffix trie - Just adding all suffixes of the keys you'd normally add to the prefix trie just to get an estimate of what it would look like.  The populating performance should increase by a fair amount if we actually wrote a real implementation.
* Full text search - Both of the popular engines we tried seemed pretty reasonable, main issue is that we'd be doing a fair amount of post filtering and sorting afterwards.

See [this Notion doc](https://www.notion.so/shortwave/Contact-Suggestions-tech-brainstorm-ef06dff1b4134076a958b1a8001b6fe7) for our notes during brainstorming.