### PR TITLE
Adding exact search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,34 @@ class Trie<T> {
 
     return results;
   }
+
+  /**
+   * Returns an array of values that have keys matching the query exactly.
+   *
+   * You are encouraged to pass an options object with:
+   * a .limit to limit the number of results returned.
+   * a .unique property if you only want one result per-key.
+   *
+   * The limit is particularly important because the performance of the
+   * algorithm is determined primarily by the limit.
+   */
+  exactSearch(query: string, opts?: Partial<SearchOptions>): T[] {
+    const results: T[] = [];
+    const node = this.root.findPrefix(query, 0);
+
+    if (!node) {
+      return results;
+    }
+
+    const options: SearchOptions = {
+      unique: opts?.unique ?? false,
+      limit: opts?.limit ?? Number.POSITIVE_INFINITY,
+    };
+
+    node.getSortedExactResults(query, results, options);
+
+    return results;
+  }
 }
 
 export { Trie as default, Item, TrieOptions, SearchOptions };

--- a/src/node.ts
+++ b/src/node.ts
@@ -243,6 +243,39 @@ class Node<T> {
     }
   }
 
+  /*
+   * Look at only the results from this node (or the empty string node this one
+   * contains) for exact matched of the query.
+   *
+   * We use the passed in pqueue which has a limit and unique flag to
+   * configure the search.
+   */
+  getSortedExactResults(query: string, results: Array<T>, opts: SearchOptions) {
+    const seenKeys = new Set<string>();
+
+    if (!this.leaf) {
+      this.children['']?.getSortedExactResults(query, results, opts);
+      return;
+    }
+
+    if (!this.sorted) {
+      this.sort();
+    }
+
+    for (let i = 0; i < this.values.length; i++) {
+      const item = this.values[i] as Item<T>;
+      if (item.key === query) {
+        if (!opts.unique || !seenKeys.has(item.distinct || item.key)) {
+          seenKeys.add(item.distinct || item.key);
+          results.push(item.value);
+          if (results.length === opts.limit) {
+            return;
+          }
+        }
+      }
+    }
+  }
+
   private sort(): void {
     if (this.sorted) {
       return;


### PR DESCRIPTION
[Task](https://app.asana.com/0/0/1200903621308177/f)

Allow searching for exact matches in addition to prefix matches.  Very similar only we won't progress down the tree after doing the initial node search (besides potentially visiting the empty string child).